### PR TITLE
docs: fix component name in React example

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ This may work better with React and other frontend frameworks, but it misses the
 import React from 'react'
 import { atcb_action } from 'add-to-calendar-button'
 
-const atcb_action = () => {
+const MyComponent = () => {
   const [name, setName] = React.useState('Some event')
   return (
       <form onSubmit={e => {


### PR DESCRIPTION
Simple change to the React example in the README. The previous component name was invalid, and a lowercase component name is confusing.